### PR TITLE
bugfix: empty properties were marked as missing properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function applySourceMap(file, sourceMap) {
 };
 
 function assertProperty(sourceMap, propertyName) {
-  if (!sourceMap[propertyName]) {
+  if (!sourceMap.hasOwnProperty(propertyName)) {
     var e = new Error('Source map to be applied is missing the \"' + propertyName + '\" property');
     throw e;
   }


### PR DESCRIPTION
I noticed gulp-uglify suddently crashing on me.  After a long search I found out it was because you added the assertProperty function.  At some point it gets fed an empty source map, i.e. the mappings property is the empty string. Because the empty string is a falsy value, it does not pass the test where I think it should. 
