### PR TITLE
Use the same sourceFile Name when applySourceMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ module.exports = function applySourceMap(file, sourceMap) {
   });
 
   if (file.sourceMap) {
-    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(sourceMap));
-    generator.applySourceMap(new SourceMapConsumer(file.sourceMap));
-    file.sourceMap = JSON.parse(generator.toString());
+    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(file.sourceMap));
+    generator.applySourceMap(new SourceMapConsumer(sourceMap), file.sourceMap.file);
+    file.sourceMap = generator.toJSON();
   } else {
     file.sourceMap = sourceMap;
   }

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ module.exports = function applySourceMap(file, sourceMap) {
   });
 
   if (file.sourceMap) {
-    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(file.sourceMap));
-    generator.applySourceMap(new SourceMapConsumer(sourceMap), file.sourceMap.file);
+    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(sourceMap));
+    generator.applySourceMap(new SourceMapConsumer(file.sourceMap), sourceMap.file);
     file.sourceMap = generator.toJSON();
   } else {
     file.sourceMap = sourceMap;


### PR DESCRIPTION
I maybe miss something but this Fix would be related to:
- https://github.com/sindresorhus/gulp-autoprefixer/issues/8
- https://github.com/floridoo/gulp-sourcemaps/issues/60

Can you tell me what do you think ?